### PR TITLE
Update ff_fitgrain.py

### DIFF
--- a/utils/ff_fitgrain.py
+++ b/utils/ff_fitgrain.py
@@ -46,7 +46,7 @@ def main():
     subprocess.call(os.path.expanduser('~/opt/MIDAS/FF_HEDM/bin/GetHKLList')+f' {psFN}',shell=True,stdout=open('hklsout.csv','w'))
 
     grs = np.genfromtxt(GrainsFN,skip_header=9)
-    grsSort = grs[grs[:,20].argsort()]
+    grsSort = grs[grs[:,19].argsort()]
     nGrs = grsSort.shape[0]
     nSpotsToRefine = nGrs // frac # We will take 1/nth of grains and refine them
     IDs = list(tuple(grsSort[:nSpotsToRefine,0]))


### PR DESCRIPTION
This script should sort by column "DiffPos" in Grains.csv, which is the 20th column, whereas the 21st column is "DiffOme". Change in Python code here sorts the grains to be used for fitting by "DiffPos".