### PR TITLE
Fixed qsort_r wsl build error

### DIFF
--- a/FF_HEDM/src/DetectorGeometry.h
+++ b/FF_HEDM/src/DetectorGeometry.h
@@ -11,6 +11,8 @@
 #ifndef DETECTOR_GEOMETRY_H
 #define DETECTOR_GEOMETRY_H
 
+#define _GNU_SOURCE
+#include <stdlib.h>
 #include <math.h>
 #include "Panel.h"
 


### PR DESCRIPTION
While building this project in WSL on windows, error qsort_r implicitly defined. Fixed by defining _GNU_SOURCE
and including stdlib.h in FF_HEDM/src/DetectorGeometry.h