### PR TITLE
Add raw binary detector support and fix η sign in HYDRA mode

### DIFF
--- a/gui/ff_asym_qt.py
+++ b/gui/ff_asym_qt.py
@@ -2281,7 +2281,14 @@ class FFViewer(QtWidgets.QMainWindow):
         bcy = float(self.bcy_edit.text() or 0)
         bcz = float(self.bcz_edit.text() or 0)
         try:
-            eta, rr = CalcEtaAngleRad(-x + bcy, y - bcz)
+            # MIDAS lab convention: +Y → display LEFT, +Z → display UP.
+            # Single-det view uses 'bl' origin (no X-flip) so display-RIGHT
+            # corresponds to large pixel-x → Y_lab = bcy - x. Multi-det
+            # composite uses 'br' origin (X-flipped) so display-LEFT
+            # corresponds to large pixel-x → Y_lab = x - bcy. Without this
+            # branch, η in HYDRA mode comes out with the wrong sign.
+            Y_lab = (x - bcy) if self.multi_mode else (-x + bcy)
+            eta, rr = CalcEtaAngleRad(Y_lab, y - bcz)
             status = (f"x={x:.1f}  y={y:.1f}  I={val:.0f}  "
                       f"R={rr:.1f}px  η={eta:.1f}°")
             # Show nearest ring info

--- a/gui/ff_asym_qt.py
+++ b/gui/ff_asym_qt.py
@@ -2582,9 +2582,12 @@ class FFViewer(QtWidgets.QMainWindow):
 
     def _on_pick_det_data(self, idx):
         fn, _ = QtWidgets.QFileDialog.getOpenFileName(
-            self, f"Select GE{idx+1} data HDF5",
+            self, f"Select GE{idx+1} data (HDF5 or raw GE binary)",
             os.path.dirname(self._det_states[idx].data_file) or os.getcwd(),
-            "HDF5 (*.h5 *.hdf5 *.hdf *.nxs);;All (*)")
+            "Detector data (*.h5 *.hdf5 *.hdf *.nxs *.ge *.ge1 *.ge2 *.ge3 "
+            "*.ge4 *.ge5 *.raw *.bin *.dat);;HDF5 (*.h5 *.hdf5 *.hdf *.nxs);;"
+            "Raw GE binary (*.ge *.ge1 *.ge2 *.ge3 *.ge4 *.ge5 *.raw *.bin *.dat);;"
+            "All (*)")
         if not fn:
             return
         self._det_states[idx].data_file = fn
@@ -2599,10 +2602,13 @@ class FFViewer(QtWidgets.QMainWindow):
 
     def _on_pick_det_dark(self, idx):
         fn, _ = QtWidgets.QFileDialog.getOpenFileName(
-            self, f"Select GE{idx+1} dark HDF5",
+            self, f"Select GE{idx+1} dark (HDF5 or raw GE binary)",
             os.path.dirname(self._det_states[idx].dark_file
                              or self._det_states[idx].data_file) or os.getcwd(),
-            "HDF5 (*.h5 *.hdf5 *.hdf *.nxs);;All (*)")
+            "Detector data (*.h5 *.hdf5 *.hdf *.nxs *.ge *.ge1 *.ge2 *.ge3 "
+            "*.ge4 *.ge5 *.raw *.bin *.dat);;HDF5 (*.h5 *.hdf5 *.hdf *.nxs);;"
+            "Raw GE binary (*.ge *.ge1 *.ge2 *.ge3 *.ge4 *.ge5 *.raw *.bin *.dat);;"
+            "All (*)")
         if not fn:
             return
         self._det_states[idx].dark_file = fn

--- a/gui/multidet.py
+++ b/gui/multidet.py
@@ -133,6 +133,9 @@ def parse_detector_param_file(fn: str) -> dict:
         'dark_file': None,             # external dark HDF5 path, if specified
         'bad_px': None,
         'gap_px': None,
+        # Raw GE binary parameters (only used when data_file is .geX/.dat/etc.).
+        'header_size': None,
+        'bytes_per_pixel': None,
         'wavelength': None, 'space_group': None,
         'lattice_constant': None, 'max_ring_rad': None,
     }
@@ -186,6 +189,9 @@ def parse_detector_param_file(fn: str) -> dict:
     out['bad_px'] = get_float('BadPxIntensity')
     out['gap_px'] = get_float('GapIntensity')
 
+    out['header_size']     = get_int('HeadSize', 'HeaderSize')
+    out['bytes_per_pixel'] = get_int('BytesPerPixel')
+
     out['wavelength']  = get_float('Wavelength')
     out['space_group'] = get_int('SpaceGroup', 'SpaceGroupNumber')
     lc = first('LatticeConstant', 'LatticeParameter')
@@ -205,49 +211,116 @@ def _normalize_h5_path(p: Optional[str]) -> Optional[str]:
     return p if p.startswith('/') else '/' + p
 
 
-# ── HDF5 IO ─────────────────────────────────────────────────────────────────
+# ── HDF5 / raw-binary IO ────────────────────────────────────────────────────
 
-def n_frames_in_h5(fn: str, loc: str) -> int:
-    """Return frame count for the given HDF5 dataset, or 0 on error."""
-    if not fn or h5py is None:
-        return 0
+_HDF5_EXTS = ('.h5', '.hdf', '.hdf5', '.nxs')
+
+
+def _is_hdf5(fn: str) -> bool:
+    return os.path.splitext(fn)[1].lower() in _HDF5_EXTS
+
+
+def _raw_n_frames(fn: str, header: int, bpp: int, ny: int, nz: int) -> int:
+    """Frame count for a raw binary stack (file size minus header / frame
+    bytes). Returns 0 on any error so the caller treats it as empty."""
     try:
-        with h5py.File(fn, 'r') as f:
-            ds = f.get(_normalize_h5_path(loc))
-            if ds is None:
-                return 0
-            return int(ds.shape[0]) if ds.ndim >= 3 else 1
+        size = os.path.getsize(fn)
     except OSError:
         return 0
+    frame_bytes = bpp * ny * nz
+    if frame_bytes <= 0 or size <= header:
+        return 0
+    return max(1, (size - header) // frame_bytes)
 
 
-def read_h5_frame(fn: str, loc: str, frame_idx: int) -> Optional[np.ndarray]:
-    """Read a single frame from an HDF5 dataset; returns float32 2-D array."""
-    if not fn or h5py is None:
-        return None
+def _raw_read_frame(fn: str, header: int, bpp: int, ny: int, nz: int,
+                    frame_idx: int) -> Optional[np.ndarray]:
     try:
-        with h5py.File(fn, 'r') as f:
-            ds = f[_normalize_h5_path(loc)]
-            if ds.ndim >= 3:
-                return ds[frame_idx].astype(np.float32)
-            return ds[...].astype(np.float32)
-    except (OSError, KeyError, IndexError):
+        dtype = np.uint16 if bpp == 2 else np.int32
+        offset = header + frame_idx * (bpp * ny * nz)
+        with open(fn, 'rb') as f:
+            f.seek(offset, os.SEEK_SET)
+            data = np.fromfile(f, dtype=dtype, count=ny * nz)
+        if data.size != ny * nz:
+            return None
+        return data.reshape((ny, nz)).astype(np.float32)
+    except OSError:
         return None
 
 
-def read_h5_dark(fn: str, loc: str) -> Optional[np.ndarray]:
-    """Read all dark frames and average them; returns float32 2-D or None."""
-    if not fn or h5py is None:
+def n_frames_in_h5(fn: str, loc: str,
+                   header: int = 8192, bpp: int = 2,
+                   ny: int = 2048, nz: int = 2048) -> int:
+    """Return frame count for `fn`. HDF5 if extension matches, otherwise
+    raw GE binary (header + bpp×ny×nz per frame). The raw kwargs are
+    ignored for HDF5 files."""
+    if not fn:
+        return 0
+    if _is_hdf5(fn):
+        if h5py is None:
+            return 0
+        try:
+            with h5py.File(fn, 'r') as f:
+                ds = f.get(_normalize_h5_path(loc))
+                if ds is None:
+                    return 0
+                return int(ds.shape[0]) if ds.ndim >= 3 else 1
+        except OSError:
+            return 0
+    return _raw_n_frames(fn, header, bpp, ny, nz)
+
+
+def read_h5_frame(fn: str, loc: str, frame_idx: int,
+                  header: int = 8192, bpp: int = 2,
+                  ny: int = 2048, nz: int = 2048) -> Optional[np.ndarray]:
+    """Read one frame from `fn` as float32 2-D. HDF5 by extension, otherwise
+    raw GE binary."""
+    if not fn:
         return None
-    try:
-        with h5py.File(fn, 'r') as f:
-            ds = f.get(_normalize_h5_path(loc))
-            if ds is None:
-                return None
-            data = ds[...].astype(np.float32)
-            return np.mean(data, axis=0) if data.ndim >= 3 else data
-    except (OSError, KeyError):
+    if _is_hdf5(fn):
+        if h5py is None:
+            return None
+        try:
+            with h5py.File(fn, 'r') as f:
+                ds = f[_normalize_h5_path(loc)]
+                if ds.ndim >= 3:
+                    return ds[frame_idx].astype(np.float32)
+                return ds[...].astype(np.float32)
+        except (OSError, KeyError, IndexError):
+            return None
+    return _raw_read_frame(fn, header, bpp, ny, nz, frame_idx)
+
+
+def read_h5_dark(fn: str, loc: str,
+                 header: int = 8192, bpp: int = 2,
+                 ny: int = 2048, nz: int = 2048) -> Optional[np.ndarray]:
+    """Read dark frames and average them; returns float32 2-D or None.
+    Averages all frames for HDF5 stacks, or all frames in the raw binary
+    stack."""
+    if not fn:
         return None
+    if _is_hdf5(fn):
+        if h5py is None:
+            return None
+        try:
+            with h5py.File(fn, 'r') as f:
+                ds = f.get(_normalize_h5_path(loc))
+                if ds is None:
+                    return None
+                data = ds[...].astype(np.float32)
+                return np.mean(data, axis=0) if data.ndim >= 3 else data
+        except (OSError, KeyError):
+            return None
+    n = _raw_n_frames(fn, header, bpp, ny, nz)
+    if n <= 0:
+        return None
+    acc = None
+    for i in range(n):
+        f = _raw_read_frame(fn, header, bpp, ny, nz, i)
+        if f is None:
+            return None
+        acc = f if acc is None else acc + f
+    return acc / float(n)
 
 
 # ── Image preprocessing (matches ff_asym_qt convention) ─────────────────────
@@ -405,6 +478,11 @@ class DetectorState:
     dark_loc: str = DEFAULT_DARK_LOC
     bad_px: Optional[float] = None
     gap_px: Optional[float] = None
+    # Raw GE binary defaults (overridden by HeadSize / BytesPerPixel in
+    # param file). Mirrors FFViewer.header_size / bytes_per_pixel for the
+    # single-detector path.
+    header_size: int = 8192
+    bytes_per_pixel: int = 2
 
     # Caches:
     _dark_image: Optional[np.ndarray] = None
@@ -416,7 +494,9 @@ class DetectorState:
         return bool(self.data_file) and bool(self.param_file)
 
     def n_frames(self) -> int:
-        return n_frames_in_h5(self.data_file, self.data_loc)
+        return n_frames_in_h5(self.data_file, self.data_loc,
+                              self.header_size, self.bytes_per_pixel,
+                              self.ny, self.nz)
 
     def load_param_file(self, fn: str) -> None:
         """Read fn, populate per-detector geometry fields.
@@ -440,6 +520,8 @@ class DetectorState:
         self.dark_loc = params['dark_loc']
         self.bad_px = params['bad_px']
         self.gap_px = params['gap_px']
+        if params['header_size']     is not None: self.header_size     = params['header_size']
+        if params['bytes_per_pixel'] is not None: self.bytes_per_pixel = params['bytes_per_pixel']
         # External dark from param file's `Dark <path>` line — only apply if
         # the file actually exists, and don't clobber a manual-pick made via
         # the GUI dark-picker.
@@ -466,7 +548,9 @@ class DetectorState:
         # key would return the cleared None forever.
         if self._dark_cache_key == key and self._dark_image is not None:
             return self._dark_image
-        dark = read_h5_dark(src, self.dark_loc)
+        dark = read_h5_dark(src, self.dark_loc,
+                            self.header_size, self.bytes_per_pixel,
+                            self.ny, self.nz)
         if dark is not None:
             dark = apply_imtransopt(dark, self.im_trans_opts)
             # Only cache successful reads — caching None freezes transient
@@ -492,7 +576,9 @@ class DetectorState:
         """Read frame, transform/mask/dark-subtract, remap into composite."""
         if not self.enabled or not self.data_file:
             return None
-        img = read_h5_frame(self.data_file, self.data_loc, frame_idx)
+        img = read_h5_frame(self.data_file, self.data_loc, frame_idx,
+                            self.header_size, self.bytes_per_pixel,
+                            self.ny, self.nz)
         if img is None:
             return None
         img = apply_imtransopt(img, self.im_trans_opts)

--- a/gui/multidet.py
+++ b/gui/multidet.py
@@ -215,28 +215,75 @@ def _normalize_h5_path(p: Optional[str]) -> Optional[str]:
 
 _HDF5_EXTS = ('.h5', '.hdf', '.hdf5', '.nxs')
 
+# Formats the single-detector reader (ff_asym_qt.read_image) handles
+# specially but the raw-binary reader below would silently misinterpret as
+# a GE stack (TIFF/CBF/zarr/bz2/...). Only HDF5 and raw GE binary are
+# supported in the multi-detector viewer; anything in this set is skipped
+# with a warning rather than rendered as byte-offset garbage.
+_NONRAW_EXTS = ('.tif', '.tiff', '.cbf', '.zip', '.zarr', '.bz2', '.edf', '.img')
+
+# Raw GE binary bytes-per-pixel we can read. The dtype (below) and the
+# frame-byte stride must agree, so only these two are accepted.
+_SUPPORTED_BPP = (2, 4)
+
 
 def _is_hdf5(fn: str) -> bool:
     return os.path.splitext(fn)[1].lower() in _HDF5_EXTS
 
 
+def _is_unsupported_multidet(fn: str) -> bool:
+    """True (and warns once) for a format the multi-detector viewer cannot
+    read but that would otherwise fall through to the raw-binary reader and
+    render as garbage."""
+    ext = os.path.splitext(fn)[1].lower()
+    if ext in _NONRAW_EXTS:
+        _warn_once(
+            f'{os.path.basename(fn)}: {ext} is not supported in the multi-detector '
+            'viewer (HDF5 and raw GE binary only) — detector skipped. Convert to '
+            'HDF5/zarr (single-detector view or the zip workflow) first.')
+        return True
+    return False
+
+
+def _raw_dtype(bpp: int):
+    return np.uint16 if bpp == 2 else np.int32  # bpp == 4
+
+
 def _raw_n_frames(fn: str, header: int, bpp: int, ny: int, nz: int) -> int:
     """Frame count for a raw binary stack (file size minus header / frame
-    bytes). Returns 0 on any error so the caller treats it as empty."""
+    bytes). Returns 0 on any error so the caller treats it as empty.
+
+    Validates that the payload is a whole number of frames and that bpp is
+    supported; a mismatch (wrong NrPixels / BytesPerPixel / HeadSize) is a
+    silent-garbage hazard, so it is surfaced with a warning instead."""
     try:
         size = os.path.getsize(fn)
     except OSError:
         return 0
+    if bpp not in _SUPPORTED_BPP:
+        _warn_once(
+            f'raw[{os.path.basename(fn)}]: BytesPerPixel={bpp} unsupported '
+            f'(only {_SUPPORTED_BPP} handled) — detector skipped.')
+        return 0
     frame_bytes = bpp * ny * nz
     if frame_bytes <= 0 or size <= header:
         return 0
-    return max(1, (size - header) // frame_bytes)
+    payload = size - header
+    if payload % frame_bytes != 0:
+        _warn_once(
+            f'raw[{os.path.basename(fn)}]: {payload} data bytes is not a whole '
+            f'number of {ny}x{nz}x{bpp}B frames ({frame_bytes} B each) — check '
+            f'NrPixels / BytesPerPixel / HeadSize. Using {payload // frame_bytes} '
+            f'full frame(s), ignoring {payload % frame_bytes} trailing bytes.')
+    return payload // frame_bytes
 
 
 def _raw_read_frame(fn: str, header: int, bpp: int, ny: int, nz: int,
                     frame_idx: int) -> Optional[np.ndarray]:
+    if bpp not in _SUPPORTED_BPP:
+        return None
     try:
-        dtype = np.uint16 if bpp == 2 else np.int32
+        dtype = _raw_dtype(bpp)
         offset = header + frame_idx * (bpp * ny * nz)
         with open(fn, 'rb') as f:
             f.seek(offset, os.SEEK_SET)
@@ -267,6 +314,8 @@ def n_frames_in_h5(fn: str, loc: str,
                 return int(ds.shape[0]) if ds.ndim >= 3 else 1
         except OSError:
             return 0
+    if _is_unsupported_multidet(fn):
+        return 0
     return _raw_n_frames(fn, header, bpp, ny, nz)
 
 
@@ -288,6 +337,8 @@ def read_h5_frame(fn: str, loc: str, frame_idx: int,
                 return ds[...].astype(np.float32)
         except (OSError, KeyError, IndexError):
             return None
+    if _is_unsupported_multidet(fn):
+        return None
     return _raw_read_frame(fn, header, bpp, ny, nz, frame_idx)
 
 
@@ -311,6 +362,8 @@ def read_h5_dark(fn: str, loc: str,
                 return np.mean(data, axis=0) if data.ndim >= 3 else data
         except (OSError, KeyError):
             return None
+    if _is_unsupported_multidet(fn):
+        return None
     n = _raw_n_frames(fn, header, bpp, ny, nz)
     if n <= 0:
         return None
@@ -540,6 +593,14 @@ class DetectorState:
         `data_file` at `dark_loc`."""
         src = self.dark_file or self.data_file
         if not src:
+            return None
+        # When no explicit dark_file is given we fall back to the data file.
+        # For HDF5 that is correct: dark_loc addresses a *separate* dark
+        # dataset inside the same file. A raw binary data file has no such
+        # separate dark — averaging the data stack and subtracting it would
+        # remove the signal's own mean from every frame. So for raw data
+        # without an explicit dark, skip subtraction instead.
+        if not self.dark_file and not _is_hdf5(self.data_file):
             return None
         key = (src, self.dark_loc, tuple(self.im_trans_opts))
         # Cache HIT only when both key matches AND a real image is stored.


### PR DESCRIPTION
This pull request adds support for reading raw GE binary image stacks (in addition to HDF5) throughout the `multidet` GUI code. It introduces new logic to detect file type by extension, read raw binary frames with configurable header size and bytes-per-pixel, and propagate these parameters from the parameter file and through all relevant data paths. The changes ensure that both HDF5 and raw binary files are handled seamlessly, with user-configurable parameters.

**Raw GE Binary File Support:**

* Added detection of raw GE binary files by extension and implemented `_raw_n_frames` and `_raw_read_frame` to count and read frames from raw binary stacks, supporting configurable header size and bytes-per-pixel. [[1]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06L208-R260) [[2]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06R270-R281)
* Updated `n_frames_in_h5`, `read_h5_frame`, and `read_h5_dark` to support both HDF5 and raw binary files, passing through the appropriate parameters and averaging all frames for dark images. [[1]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06L208-R260) [[2]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06R270-R281) [[3]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06R291-R303) [[4]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06R314-R323)

**Parameter Handling and Propagation:**

* Extended parameter parsing to recognize and store `header_size` and `bytes_per_pixel` from the parameter file, and added these fields to `DetectorState` with sensible defaults. [[1]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06R136-R138) [[2]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06R192-R194) [[3]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06R481-R485) [[4]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06R523-R524)
* Ensured that all relevant methods in `DetectorState` (frame counting, frame reading, dark image reading) pass these parameters through to the underlying IO functions. [[1]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06L419-R499) [[2]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06L469-R553) [[3]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06L495-R581)

**Documentation and Comments:**

* Added detailed comments explaining the rationale for file handling logic and parameter propagation, improving maintainability. [[1]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06L208-R260) [[2]](diffhunk://#diff-9924280f57b81e5ed6229a6c8f5af9fac8e7690522d26bb3a4ff6ac19c585c06R481-R485)

**Bug Fix:**

* Fixed the sign convention for η angle calculation in HYDRA mode in `ff_asym_qt.py` for correct display orientation.multidet.py:
- Add raw GE binary (.geX / .dat) support alongside HDF5 for data, dark and parameter reading. HeadSize / BytesPerPixel from the param file control the byte offset and dtype; defaults match the standard GE format (8192-byte header, uint16).
- Parse HeaderSize / BytesPerPixel from detector parameter files into DetectorState so each detector can carry its own raw-IO settings.
- Refactor n_frames_in_h5 / read_h5_frame / read_h5_dark into unified helpers that dispatch on file extension (_is_hdf5) and fall through to the raw binary path when the extension is not HDF5.

ff_asym_qt.py:
- Fix η calculation sign in HYDRA multi-detector composite mode. Single-det view uses 'bl' origin (no X-flip): Y_lab = bcy - x. Multi-det composite uses 'br' origin (X-flipped): Y_lab = x - bcy. Without this branch η had the wrong sign in HYDRA mode.