### PR TITLE
midas-pipeline: port --run-sr from midas_ff_pipeline, fix path conven…

### DIFF
--- a/packages/midas_pipeline/midas_pipeline/_sr_worker.py
+++ b/packages/midas_pipeline/midas_pipeline/_sr_worker.py
@@ -1,0 +1,58 @@
+"""Subprocess worker for the sr-midas branch of the FF `peakfit` stage.
+
+Runs `sr_midas.pipeline.sr_process.run_sr_process` in a throwaway process
+so its CUDA context is fully released on exit, before indexing/refinement
+claim the GPU. See stages/peakfit.py::_run_sr_subprocess for why this needs
+to be a subprocess rather than an in-process call.
+
+Not a public CLI — invoked internally as:
+    python -m midas_pipeline._sr_worker <result_dir> [options]
+Exits 0 on success, 2 if sr-midas isn't importable, 1 on any other failure
+(with a traceback on stderr for the caller's log file to capture).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("result_dir", help="Directory containing the *.MIDAS.zip")
+    p.add_argument("--srfac", type=int, default=8)
+    p.add_argument("--sr-config", default=None,
+                    help="Path to a custom sr_config.json; omit for the bundled default")
+    p.add_argument("--save-sr-patches", type=int, default=0, choices=[0, 1])
+    p.add_argument("--save-frame-good-coords", type=int, default=0, choices=[0, 1])
+    p.add_argument("--use-gpu", type=int, default=1, choices=[0, 1])
+    p.add_argument("--peak-fit-method", default=None,
+                    help="Override sr_config's peak_fit_method (e.g. midas_lm, gpu_adam)")
+    p.add_argument("--max-frames", type=int, default=None)
+    args = p.parse_args(argv)
+
+    try:
+        from sr_midas.pipeline.sr_process import run_sr_process
+    except ImportError as e:
+        print(f"sr-midas is not importable: {e}", file=sys.stderr)
+        return 2
+
+    kwargs = dict(
+        midasZarrDir=args.result_dir,
+        srfac=args.srfac,
+        saveSRpatches=args.save_sr_patches,
+        saveFrameGoodCoords=args.save_frame_good_coords,
+        use_gpu=args.use_gpu,
+    )
+    if args.sr_config is not None:
+        kwargs["SRconfig_path"] = args.sr_config
+    if args.peak_fit_method is not None:
+        kwargs["peak_fit_method"] = args.peak_fit_method
+    if args.max_frames is not None:
+        kwargs["max_frames"] = args.max_frames
+
+    run_sr_process(**kwargs)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/midas_pipeline/midas_pipeline/config.py
+++ b/packages/midas_pipeline/midas_pipeline/config.py
@@ -559,6 +559,19 @@ class PipelineConfig:
         if self.scan.is_ff and self.recon.do_tomo:
             # Soft: tomography is meaningless in FF; disable silently.
             self.recon = ReconConfig(do_tomo=False, method=self.recon.method)
+        # sr-midas: fail fast, not mid-pipeline after zip_convert/hkl already
+        # ran. (The original ff_MIDAS.py-era shim had this check
+        # (validate_sr_midas_flags); it was dropped when ported into this
+        # package and midas_ff_pipeline — neither restored it.)
+        if self.run_sr:
+            try:
+                import sr_midas  # noqa: F401
+            except Exception as e:
+                raise ValueError(
+                    "run_sr=True but sr-midas is not installed/importable "
+                    f"({e}). Install it (`pip install sr-midas`) or drop "
+                    "--run-sr."
+                ) from e
 
     # --- Convenience -------------------------------------------------
 

--- a/packages/midas_pipeline/midas_pipeline/stages/indexing.py
+++ b/packages/midas_pipeline/midas_pipeline/stages/indexing.py
@@ -89,6 +89,16 @@ def _run_ff(ctx: StageContext) -> StageResult:
     out_dir = layer_dir / "Output"
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    # Clear IndexBest outputs left by a previous run, from BOTH the c-omp
+    # (Output/) and python (bare layer_dir) conventions, before regenerating
+    # them. process_grains' backend-agnostic readers resolve subfolder-first
+    # then fall back to the bare path; without this a leftover file from the
+    # *other* backend's location would shadow (or mix with) this run's fresh
+    # output and silently feed stale records downstream.
+    for _stale in (out_dir / "IndexBest.bin", out_dir / "IndexBestFull.bin",
+                   layer_dir / "IndexBest.bin", layer_dir / "IndexBestFull.bin"):
+        _stale.unlink(missing_ok=True)
+
     if ctx.config.indexer_backend == "c-omp":
         from midas_index import backend_c
         from ._comp_params import comp_backend_paramstest

--- a/packages/midas_pipeline/midas_pipeline/stages/peakfit.py
+++ b/packages/midas_pipeline/midas_pipeline/stages/peakfit.py
@@ -52,6 +52,19 @@ def _run_ff(ctx: StageContext, started: float, peakfit_run) -> StageResult:
         LOG.info("peakfit(FF): %s already exists; skip.", target)
         return _result(started, [target], 1, 0)
     target.parent.mkdir(parents=True, exist_ok=True)
+
+    if cfg.run_sr:
+        from .. import sr_midas
+        sr_midas.log_status(LOG, run_sr=True)
+        _run_sr_subprocess(ctx, layer_dir)
+        if not target.exists():
+            raise RuntimeError(
+                f"peakfit(FF): SR-MIDAS reported success but {target} "
+                "was not written."
+            )
+        LOG.info("peakfit(FF): SR-MIDAS wrote %s", target)
+        return _result(started, [target], 1, 0)
+
     peakfit_run(
         data_file=str(zip_path),
         block_nr=0, n_blocks=1, num_procs=max(1, cfg.n_cpus_local),
@@ -61,6 +74,38 @@ def _run_ff(ctx: StageContext, started: float, peakfit_run) -> StageResult:
     )
     LOG.info("peakfit(FF): wrote %s", target)
     return _result(started, [target], 1, 0)
+
+
+def _run_sr_subprocess(ctx: StageContext, layer_dir: Path) -> None:
+    """Run SR-MIDAS peak search in a throwaway subprocess.
+
+    Isolation, not convenience: sr-midas's CNN cascade + GPU peak-fit hold
+    a large CUDA context (empirically ~20GB+) that is never released while
+    the interpreter stays alive. Running it in-process (as midas_ff_pipeline
+    currently does) leaves that memory resident into the indexing/refinement
+    stages that follow, which then OOM. A subprocess guarantees the context
+    is torn down when it exits, matching how stages/indexing.py and
+    stages/refinement.py already isolate their own GPU-heavy FF work.
+    """
+    import sys
+    from ._base import run_subprocess
+
+    cfg = ctx.config
+    cmd = [
+        sys.executable, "-m", "midas_pipeline._sr_worker",
+        str(layer_dir),
+        "--srfac", str(cfg.srfac),
+        "--save-sr-patches", "1" if cfg.save_sr_patches else "0",
+        "--save-frame-good-coords", "1" if cfg.save_frame_good_coords else "0",
+        "--use-gpu", "1" if cfg.device.startswith("cuda") else "0",
+    ]
+    if cfg.sr_config_path and cfg.sr_config_path != "auto":
+        cmd += ["--sr-config", cfg.sr_config_path]
+    run_subprocess(
+        cmd, cwd=layer_dir,
+        stdout_path=ctx.log_dir / "peakfit_sr_out.log",
+        stderr_path=ctx.log_dir / "peakfit_sr_err.log",
+    )
 
 
 def _run_pf(ctx: StageContext, started: float, peakfit_run) -> StageResult:

--- a/packages/midas_pipeline/midas_pipeline/stages/process_grains.py
+++ b/packages/midas_pipeline/midas_pipeline/stages/process_grains.py
@@ -43,12 +43,16 @@ def run(ctx: StageContext) -> StageResult:
         pg_paramstest = comp_backend_paramstest(paramstest, layer_dir)
 
     # Spot-aware / paper_claim modes need the per-spot residual table
-    # (Output/FitBest.bin), which the python refiner writes but the c-omp
-    # refiner does not (it emits Results/ProcessKey.bin). Fall back to legacy
-    # (single grain per cluster, dedup from OrientPosFit + ProcessKey) so the
-    # c-omp backend runs end-to-end.
+    # (Output/FitBest.bin, or bare FitBest.bin — see opf resolution above),
+    # which the python refiner writes but the c-omp refiner does not (it
+    # emits Results/ProcessKey.bin). Fall back to legacy (single grain per
+    # cluster, dedup from OrientPosFit + ProcessKey) so the c-omp backend
+    # runs end-to-end.
     mode = ctx.config.process_grains_mode
-    if mode != "legacy" and not (layer_dir / "Output" / "FitBest.bin").exists():
+    fit_best = layer_dir / "Output" / "FitBest.bin"
+    if not fit_best.exists():
+        fit_best = layer_dir / "FitBest.bin"
+    if mode != "legacy" and not fit_best.exists():
         LOG.info("process_grains(FF): FitBest.bin absent (c-omp refiner) → "
                  "using legacy mode (%r needs the per-spot FitBest.bin).", mode)
         mode = "legacy"

--- a/packages/midas_pipeline/midas_pipeline/stages/refinement.py
+++ b/packages/midas_pipeline/midas_pipeline/stages/refinement.py
@@ -50,6 +50,18 @@ def _run_ff(ctx: StageContext) -> StageResult:
     output_dir.mkdir(parents=True, exist_ok=True)
     results_dir.mkdir(parents=True, exist_ok=True)
 
+    # Clear refiner outputs left by a previous run, from BOTH the c-omp
+    # (Output//Results/) and python (bare layer_dir) conventions, before
+    # regenerating them — so process_grains' backend-agnostic readers can't
+    # resolve a stale file from the other backend's location and mix it with
+    # this run's fresh records. IndexBest_all.bin is refinement's *input* and
+    # is deliberately left intact.
+    for _stale in (results_dir / "OrientPosFit.bin", results_dir / "Key.bin",
+                   results_dir / "ProcessKey.bin", output_dir / "FitBest.bin",
+                   layer_dir / "OrientPosFit.bin", layer_dir / "Key.bin",
+                   layer_dir / "ProcessKey.bin", layer_dir / "FitBest.bin"):
+        _stale.unlink(missing_ok=True)
+
     # The 2D 'pixel' loss is removed (it omitted omega and gave poor,
     # under-determined fits); refinement always uses a full 3D / angular loss.
     loss = ctx.config.refinement.loss

--- a/packages/midas_pipeline/pyproject.toml
+++ b/packages/midas_pipeline/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # per-ring intensities for the V-map. Without it a clean production
     # install raises CifBackendError at that stage.
     "midas-hkls[cif]>=0.2.0",
-    "midas-peakfit>=0.2.0",
+    "midas-peakfit>=0.4.5",                # 2026-07-29 LM memory-safety fixes; sr-midas's midas_lm fitter needs these
     "midas-transforms>=0.1.1",
     "midas-index>=0.3.0",
     "midas-fit-grain>=0.1.0a0",
@@ -65,6 +65,10 @@ notebook = ["matplotlib", "ipykernel", "jupyter"]
 # its shared object when torch is imported before numba (observed on
 # Linux + torch 2.12). 0.65/0.47 loads cleanly regardless of import order.
 fast = ["numba>=0.65"]
+# Super-resolution peak search (--run-sr). Optional: sr_midas is imported
+# lazily and PipelineConfig fails fast with a clear error if run_sr=True
+# without it installed (see config.py::__post_init__).
+sr = ["sr-midas>=0.4.0"]
 
 [project.scripts]
 midas-pipeline = "midas_pipeline.cli:main"

--- a/packages/midas_pipeline/tests/unit/test_config.py
+++ b/packages/midas_pipeline/tests/unit/test_config.py
@@ -195,6 +195,20 @@ class TestPipelineConfig:
         )
         assert cfg.recon.do_tomo is False
 
+    def test_run_sr_without_sr_midas_raises(self, tmp_path, monkeypatch):
+        """run_sr=True must fail fast if sr-midas isn't importable, not
+        silently no-op mid-pipeline (the original ff_MIDAS.py-era shim had
+        this guard; it was dropped from both package ports)."""
+        import sys
+        monkeypatch.setitem(sys.modules, "sr_midas", None)
+        params = tmp_path / "P.txt"
+        params.write_text("")
+        with pytest.raises(ValueError, match="sr-midas is not installed"):
+            PipelineConfig(
+                result_dir=str(tmp_path / "r"), params_file=str(params),
+                scan=ScanGeometry.ff(), run_sr=True,
+            )
+
 
 # ---------------------------------------------------------------------------
 # sniff_scan_mode_from_paramfile

--- a/packages/midas_pipeline/tests/unit/test_stage_peakfit_sr.py
+++ b/packages/midas_pipeline/tests/unit/test_stage_peakfit_sr.py
@@ -1,0 +1,93 @@
+"""FF `peakfit` stage's sr-midas branch.
+
+``run_sr=True`` replaces the conventional ``midas_peakfit`` in-process call
+with a subprocess invocation of ``python -m midas_pipeline._sr_worker`` —
+isolation so the SR CNN cascade + GPU peak-fit's CUDA context is torn down
+before indexing/refinement claim the GPU (see stages/peakfit.py::
+_run_sr_subprocess). These tests mock ``subprocess.run`` and never actually
+import sr_midas or touch a GPU.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from midas_pipeline.config import PipelineConfig, ScanGeometry
+from midas_pipeline.stages import peakfit
+from midas_pipeline.stages._base import StageContext
+
+
+def _sr_ctx(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **cfg_kwargs) -> StageContext:
+    # PipelineConfig.__post_init__ fails fast unless sr_midas is importable.
+    monkeypatch.setitem(sys.modules, "sr_midas", SimpleNamespace())
+    params = tmp_path / "P.txt"
+    params.write_text("SpaceGroup 225\n")
+    cfg = PipelineConfig(
+        result_dir=str(tmp_path / "run"),
+        params_file=str(params),
+        scan=ScanGeometry.ff(),
+        device="cpu", dtype="float64",
+        n_cpus=4,
+        run_sr=True, srfac=8,
+        **cfg_kwargs,
+    )
+    layer_dir = tmp_path / "Layer1"
+    layer_dir.mkdir(exist_ok=True)
+    (layer_dir / "dummy.MIDAS.zip").write_text("")
+    log_dir = layer_dir / "midas_log"
+    log_dir.mkdir(exist_ok=True)
+    return StageContext(config=cfg, layer_nr=1, layer_dir=layer_dir, log_dir=log_dir)
+
+
+def test_run_sr_invokes_worker_subprocess_not_conventional_peakfit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    seen = {}
+    conventional_calls = []
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["cwd"] = kwargs.get("cwd")
+        # The SR worker is responsible for producing this in a real run;
+        # simulate that here so _run_ff's post-condition check passes.
+        (tmp_path / "Layer1" / "Temp").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "Layer1" / "Temp" / "AllPeaks_PS.bin").write_bytes(b"")
+        return SimpleNamespace(returncode=0)
+
+    def fake_peakfit_run(**kwargs):
+        conventional_calls.append(kwargs)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    ctx = _sr_ctx(tmp_path, monkeypatch, save_sr_patches=True)
+
+    # Call _run_ff directly (bypassing peakfit.run()'s `midas_peakfit`
+    # importability check) since only the SR branch is under test here.
+    peakfit._run_ff(ctx, started=0.0, peakfit_run=fake_peakfit_run)
+
+    assert not conventional_calls, "conventional peakfit_run must not be called when run_sr=True"
+    assert seen["cmd"][1:3] == ["-m", "midas_pipeline._sr_worker"]
+    assert seen["cmd"][3] == str(ctx.layer_dir)
+    assert "--srfac" in seen["cmd"] and "8" in seen["cmd"]
+    assert "--save-sr-patches" in seen["cmd"]
+    save_idx = seen["cmd"].index("--save-sr-patches")
+    assert seen["cmd"][save_idx + 1] == "1"
+    assert seen["cwd"] == str(ctx.layer_dir)
+
+
+def test_run_sr_raises_if_target_missing_after_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    """A worker subprocess that exits 0 but writes nothing is a bug, not a
+    soft-skip — the stage must surface it loudly."""
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    ctx = _sr_ctx(tmp_path, monkeypatch)
+
+    with pytest.raises(RuntimeError, match="was not written"):
+        peakfit._run_ff(ctx, started=0.0, peakfit_run=lambda **kw: None)

--- a/packages/midas_process_grains/midas_process_grains/io/binary.py
+++ b/packages/midas_process_grains/midas_process_grains/io/binary.py
@@ -100,6 +100,20 @@ def _assert_native(arr: np.ndarray, fname: str) -> None:
         )
 
 
+def _resolve(run_dir: Union[str, Path], subfolder: str, filename: str) -> Path:
+    """Resolve *filename* under ``run_dir/subfolder`` (c-omp convention) or,
+    if absent, directly under ``run_dir`` (the bare-``OutputFolder``/
+    ``ResultFolder`` convention the python indexer/refiner write natively —
+    see ``midas_index``/``midas_fit_grain``'s ``ResultFolder`` docs). Callers
+    still get a ``FileNotFoundError`` naming the subfolder path when neither
+    exists, since that's the conventional/expected location."""
+    sub = Path(run_dir) / subfolder / filename
+    if sub.exists():
+        return sub
+    bare = Path(run_dir) / filename
+    return bare if bare.exists() else sub
+
+
 # ---------------------------------------------------------------------------
 # Result container
 # ---------------------------------------------------------------------------
@@ -130,7 +144,7 @@ class BinaryInputs:
 
 def read_index_best(run_dir: Union[str, Path]) -> np.memmap:
     """Read ``Output/IndexBest.bin`` into a (N, 15) float64 memmap."""
-    p = Path(run_dir) / "Output" / "IndexBest.bin"
+    p = _resolve(run_dir, "Output", "IndexBest.bin")
     if not p.exists():
         raise FileNotFoundError(p)
     arr = np.memmap(p, dtype=np.float64, mode="r")
@@ -157,7 +171,7 @@ def read_index_best_full(run_dir: Union[str, Path]) -> np.ndarray:
     table from FitBest col0 (col1/delta-omega is set to 0; it only feeds
     the residual tiebreak in spot-conflict resolution, not grain count).
     """
-    p = Path(run_dir) / "Output" / "IndexBestFull.bin"
+    p = _resolve(run_dir, "Output", "IndexBestFull.bin")
     if p.exists():
         arr = np.memmap(p, dtype=np.float64, mode="r")
         _assert_native(arr, str(p))
@@ -168,14 +182,14 @@ def read_index_best_full(run_dir: Union[str, Path]) -> np.ndarray:
             )
         return arr.reshape(-1, MAX_N_HKLS, 2)
 
-    fb_path = Path(run_dir) / "Output" / "FitBest.bin"
+    fb_path = _resolve(run_dir, "Output", "FitBest.bin")
     if not fb_path.exists():
         # c-omp FF refiner (FitUnified) emits Results/ProcessKey.bin — the
         # matched SpotID per hkl slot per seed — instead of the Output/
         # consolidated FitBest.bin. It carries the col-0 information ibf needs
         # (the matched-SpotID set per seed; col 1 / delta-omega is unused for
         # grain count), so synthesize the table from it.
-        pk_path = Path(run_dir) / "Results" / "ProcessKey.bin"
+        pk_path = _resolve(run_dir, "Results", "ProcessKey.bin")
         if pk_path.exists():
             pk = read_process_key(run_dir)          # (N, 5000) int32
             ibf = np.zeros((pk.shape[0], MAX_N_HKLS, 2), dtype=np.float64)
@@ -211,7 +225,7 @@ def read_fit_best(run_dir: Union[str, Path]) -> np.memmap:
     the readable view; longer-than-expected files are still rejected as
     corrupt.
     """
-    p = Path(run_dir) / "Output" / "FitBest.bin"
+    p = _resolve(run_dir, "Output", "FitBest.bin")
     if not p.exists():
         raise FileNotFoundError(p)
     arr = np.memmap(p, dtype=np.float64, mode="r")
@@ -228,7 +242,7 @@ def read_fit_best(run_dir: Union[str, Path]) -> np.memmap:
 
 def read_orient_pos_fit(run_dir: Union[str, Path]) -> np.memmap:
     """Read ``Results/OrientPosFit.bin`` into a (N, 27) float64 memmap."""
-    p = Path(run_dir) / "Results" / "OrientPosFit.bin"
+    p = _resolve(run_dir, "Results", "OrientPosFit.bin")
     if not p.exists():
         raise FileNotFoundError(p)
     arr = np.memmap(p, dtype=np.float64, mode="r")
@@ -246,7 +260,7 @@ def read_key(run_dir: Union[str, Path]) -> np.memmap:
 
     Columns: (keep_flag, NrIDsPerID). A seed is alive iff ``keep_flag != 0``.
     """
-    p = Path(run_dir) / "Results" / "Key.bin"
+    p = _resolve(run_dir, "Results", "Key.bin")
     if not p.exists():
         raise FileNotFoundError(p)
     arr = np.memmap(p, dtype=np.int32, mode="r")
@@ -260,7 +274,7 @@ def read_key(run_dir: Union[str, Path]) -> np.memmap:
 
 def read_process_key(run_dir: Union[str, Path]) -> np.memmap:
     """Read ``Results/ProcessKey.bin`` into a (N, 5000) int32 memmap."""
-    p = Path(run_dir) / "Results" / "ProcessKey.bin"
+    p = _resolve(run_dir, "Results", "ProcessKey.bin")
     if not p.exists():
         raise FileNotFoundError(p)
     arr = np.memmap(p, dtype=np.int32, mode="r")

--- a/packages/midas_process_grains/tests/test_io_binary.py
+++ b/packages/midas_process_grains/tests/test_io_binary.py
@@ -104,3 +104,62 @@ def test_read_all_can_skip_optional_files(tiny_run_dir):
     )
     assert inputs.fit_best is None
     assert inputs.index_best_full is None
+
+
+def _relocate_bins_to_bare(run_dir):
+    """Move every binary out of the c-omp Output/Results subfolders into the
+    bare run dir — the layout the python indexer/refiner backend writes."""
+    import shutil
+    for sub in ("Output", "Results"):
+        d = run_dir / sub
+        for f in list(d.iterdir()):
+            shutil.move(str(f), str(run_dir / f.name))
+        d.rmdir()
+
+
+def test_read_all_resolves_bare_python_backend_layout(tiny_run_dir):
+    """The python backend writes bins directly into the run dir (no Output/
+    Results subfolders). read_all must resolve them via _resolve's bare-path
+    fallback and yield the same records as the c-omp subfolder layout."""
+    # Copy expected records out of the mmaps before relocating the files.
+    exp_opf = np.array(read_orient_pos_fit(tiny_run_dir))
+    exp_pk = np.array(read_process_key(tiny_run_dir))
+    exp_fb = np.array(read_fit_best(tiny_run_dir))
+    exp_ib = np.array(read_index_best(tiny_run_dir))
+    exp_ibf = np.array(read_index_best_full(tiny_run_dir))
+
+    _relocate_bins_to_bare(tiny_run_dir)
+    assert not (tiny_run_dir / "Output").exists()
+    assert not (tiny_run_dir / "Results").exists()
+
+    np.testing.assert_array_equal(np.asarray(read_orient_pos_fit(tiny_run_dir)), exp_opf)
+    np.testing.assert_array_equal(np.asarray(read_process_key(tiny_run_dir)), exp_pk)
+    np.testing.assert_array_equal(np.asarray(read_fit_best(tiny_run_dir)), exp_fb)
+    np.testing.assert_array_equal(np.asarray(read_index_best(tiny_run_dir)), exp_ib)
+    np.testing.assert_array_equal(np.asarray(read_index_best_full(tiny_run_dir)), exp_ibf)
+
+    bundle = read_all(tiny_run_dir)
+    assert bundle.n_seeds == 3
+    assert bundle.fit_best is not None and bundle.index_best_full is not None
+
+
+def test_resolve_prefers_subfolder_then_falls_back_to_bare(tiny_run_dir):
+    """_resolve is subfolder-first, then bare. (The pipeline index/refine
+    stages clear stale bins from both locations before regenerating, so the
+    two never disagree in practice; this pins the documented precedence.)"""
+    from midas_process_grains.io.binary import _resolve
+
+    # Both present → subfolder wins.
+    (tiny_run_dir / "OrientPosFit.bin").write_bytes(b"decoy")
+    assert _resolve(tiny_run_dir, "Results", "OrientPosFit.bin") == \
+        tiny_run_dir / "Results" / "OrientPosFit.bin"
+
+    # Subfolder gone → falls back to the bare copy.
+    (tiny_run_dir / "Results" / "OrientPosFit.bin").unlink()
+    assert _resolve(tiny_run_dir, "Results", "OrientPosFit.bin") == \
+        tiny_run_dir / "OrientPosFit.bin"
+
+    # Neither present → returns the subfolder path (names the expected location).
+    (tiny_run_dir / "OrientPosFit.bin").unlink()
+    assert _resolve(tiny_run_dir, "Results", "Missing.bin") == \
+        tiny_run_dir / "Results" / "Missing.bin"


### PR DESCRIPTION
Port SR-MIDAS super-resolution peak search into midas_pipeline's FF `peakfit` stage, running it in a subprocess (midas_pipeline/_sr_worker.py) rather than in-process like midas_ff_pipeline does. sr-midas's CNN cascade
+ GPU peak-fit hold a large CUDA context (~20GB+) that is never released while the interpreter stays alive; in-process this leaves the memory resident into the indexing/refinement stages that follow and OOMs them. A subprocess guarantees the context is torn down on exit, matching how stages/indexing.py and stages/refinement.py already isolate their own GPU-heavy work.

PipelineConfig now fails fast with a clear ValueError if run_sr=True but sr-midas isn't importable, instead of failing silently mid-pipeline after zip_convert/hkl have already run (the original ff_MIDAS.py-era shim had this check; it was dropped when both midas_ff_pipeline and midas_pipeline were ported from it). pyproject.toml gains an `sr` extra and bumps the midas-peakfit floor to >=0.4.5 for the memory-safety fixes sr-midas's midas_lm fitter depends on.

Also fixes two pre-existing bugs found while running the first real end-to-end GPU smoke test of `--indexer-backend python` for FF: the python indexer/refiner write directly into the bare layer_dir, but process_grains.py's FitBest.bin mode-detection check and all 6 binary readers in midas_process_grains/io/binary.py (IndexBest, IndexBestFull, FitBest, OrientPosFit, Key, ProcessKey) only looked in the legacy Output/Results subfolders the c-omp backend uses. Both now check the subfolder path first, then fall back to the bare path, so both backends keep working. Unrelated to the SR-MIDAS port itself, but blocked completing its smoke test.

Validated end-to-end on real GPU data (copland, 2x RTX A6000): confirmed via nvidia-smi that GPU memory drops from ~11GB to 9MiB immediately after the SR peakfit subprocess exits, before indexing claims the GPU.