### PR TITLE
midas-fit-grain: fix cyclic DiffPos/DiffOme/DiffAngle column swap

### DIFF
--- a/packages/midas_fit_grain/midas_fit_grain/c_port.py
+++ b/packages/midas_fit_grain/midas_fit_grain/c_port.py
@@ -413,7 +413,15 @@ def calc_angle_errors(
       [9] FitRMSE       (per-spot peak-fit RMSE; weighted by weight_fit_rmse)
 
     Returns ``(spots_comp, spots_yzog_corr, error_ini, n_matched)`` where
-    ``spots_comp`` is the ``(n_matched, 22)`` FitBest row buffer.
+    ``spots_comp`` is the ``(n_matched, 22)`` FitBest row buffer and
+    ``error_ini`` is ``(mean_angle_deg, mean_pos_um, mean_ome_deg)`` — the
+    per-matched-spot means of ``(min_angle, diff_len, diff_ome)`` in that
+    order (matches C's ``MatchDiff[i][0..2]`` and ``Error[0..2]`` mapping
+    in ``FitPosOrStrainsOMP.c:686-719``). ``mean_angle_deg`` is bounded
+    ``< 1.0`` and ``mean_ome_deg`` is bounded ``< 5.0`` by the matching
+    filters above; ``mean_pos_um`` is unbounded. Callers must not assume
+    this tuple is already in OrientPosFit.bin column order (22=pos,
+    23=ome, 24=angle) — unpack by name, not position.
     """
     S = int(spots_yzo.shape[0])
 

--- a/packages/midas_fit_grain/midas_fit_grain/driver.py
+++ b/packages/midas_fit_grain/midas_fit_grain/driver.py
@@ -644,16 +644,20 @@ def refine_block_from_disk(
         else:
             mean_radius = 0.0
 
-        # OrientPosFit.bin row.
+        # OrientPosFit.bin row. err_ini is (mean_angle_deg, mean_pos_um,
+        # mean_ome_deg) per calc_angle_errors's match_diff column order —
+        # unpack by name rather than index so the OrientPosFit.bin cols
+        # 22-24 (ErrorPos/ErrorOme/ErrorAngle) don't silently swap again.
+        mean_angle_deg, mean_pos_um, mean_ome_deg = err_ini
         completeness = float(n_matched) / max(int(obs.n_spots), 1)
         grain_result = GrainResult(
             SpotID=sid,
             OrientMat=OM.reshape(-1),
             Position=pos_um,
             LatticeFit=lat_c,
-            ErrorPos=err_ini[0],
-            ErrorOrient=err_ini[1],
-            ErrorStrain=err_ini[2],
+            ErrorPos=mean_pos_um,
+            ErrorOme=mean_ome_deg,
+            ErrorAngle=mean_angle_deg,
             meanRadius=mean_radius,
             completeness=completeness,
         )

--- a/packages/midas_fit_grain/midas_fit_grain/io_binary.py
+++ b/packages/midas_fit_grain/midas_fit_grain/io_binary.py
@@ -102,14 +102,22 @@ class ExtraInfoSpot:
 
 @dataclass
 class GrainResult:
-    """One refined grain — packed into 27 doubles for OrientPosFit.bin."""
+    """One refined grain — packed into 27 doubles for OrientPosFit.bin.
+
+    ``ErrorPos``/``ErrorOme``/``ErrorAngle`` map to OrientPosFit.bin cols
+    22-24, which ``midas_process_grains`` reads back as Grains.csv's
+    ``DiffPos``/``DiffOme``/``DiffAngle`` (see ``FitPosOrStrainsOMP.c``
+    ``CalcAngleErrors``: ``Error[0]``=PosErr, ``Error[1]``=OmeErr,
+    ``Error[2]``=IntAngle, and its ``OutMatr[22..24]`` assignment). Do not
+    reorder without updating that column contract.
+    """
     SpotID: int
     OrientMat: np.ndarray         # (9,) row-major 3x3
     Position: np.ndarray          # (3,)  um
     LatticeFit: np.ndarray        # (6,)  refined a,b,c,alpha,beta,gamma
-    ErrorPos: float
-    ErrorOrient: float
-    ErrorStrain: float
+    ErrorPos: float     # mean matched-spot position error, um
+    ErrorOme: float     # mean matched-spot omega error, deg
+    ErrorAngle: float   # mean matched-spot internal angle error, deg
     meanRadius: float
     completeness: float
 
@@ -123,8 +131,8 @@ class GrainResult:
         out[15:21] = self.LatticeFit
         out[21] = self.SpotID
         out[22] = self.ErrorPos
-        out[23] = self.ErrorOrient
-        out[24] = self.ErrorStrain
+        out[23] = self.ErrorOme
+        out[24] = self.ErrorAngle
         out[25] = self.meanRadius
         out[26] = self.completeness
         return out

--- a/packages/midas_fit_grain/pyproject.toml
+++ b/packages/midas_fit_grain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "midas-fit-grain"
-version = "0.5.6"
+version = "0.5.7"
 description = "PyTorch single/multi-grain refiner (drop-in replacement for FitPosOrStrainsOMP / FitPosOrStrainsGPU) + bundled c-omp C refiner"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/packages/midas_fit_grain/tests/test_c_port.py
+++ b/packages/midas_fit_grain/tests/test_c_port.py
@@ -1,0 +1,128 @@
+"""Regression test for the DiffPos/DiffOme/DiffAngle column-mislabeling bug.
+
+``calc_angle_errors`` returns its three-element error tuple as
+``(mean_angle_deg, mean_pos_um, mean_ome_deg)`` (see its docstring and
+``FitPosOrStrainsOMP.c::CalcAngleErrors`` lines 686-719). ``driver.py`` must
+unpack that tuple into ``GrainResult.ErrorPos``/``ErrorOme``/``ErrorAngle``
+so they land in ``OrientPosFit.bin`` cols 22/23/24 — which
+``midas_process_grains`` reads back as Grains.csv's
+``DiffPos``/``DiffOme``/``DiffAngle`` respectively. A prior version of
+``driver.py`` assigned ``err_ini[0..2]`` straight into
+``ErrorPos/ErrorOrient/ErrorStrain`` in tuple order, cyclically swapping all
+three columns' meanings without changing their header labels.
+
+This test builds one fully-controlled synthetic matched spot with a known,
+mutually distinguishable magnitude for each of the three residuals — a
+position error (250 um, unbounded by any filter), an omega error (2.5 deg,
+bounded < 5 deg by the matching window), and an internal angle error
+(0.05 deg, bounded < 1 deg by the match-acceptance threshold) — and checks
+that each value ends up in the OrientPosFit.bin column its header claims,
+not just that values round-trip unchanged through the binary layer (that
+part is already covered by test_io_binary.py).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from midas_fit_grain import c_port
+from midas_fit_grain.io_binary import GrainResult
+
+LSD = 1_000_000.0       # um
+WAVELENGTH = 0.1729     # Angstrom
+RING_NR = 1
+
+POS_ERR_UM = 250.0      # deliberately large / unbounded-scale
+OME_ERR_DEG = 2.5       # deliberately mid-scale, < 5 deg matching window
+ANGLE_ERR_DEG = 0.05    # deliberately small, < 1 deg match-accept threshold
+
+
+def _rotate_by_small_angle(v: np.ndarray, angle_deg: float) -> np.ndarray:
+    """Rotate 3-vector ``v`` by ``angle_deg`` about an axis perpendicular to
+    it, preserving ``|v|`` and making the angle between input and output
+    exactly ``angle_deg`` (up to floating point)."""
+    u = v / np.linalg.norm(v)
+    w = np.array([1.0, 0.0, 0.0])
+    if abs(np.dot(u, w)) > 0.9:
+        w = np.array([0.0, 1.0, 0.0])
+    k = np.cross(u, w)
+    k /= np.linalg.norm(k)
+    theta = np.deg2rad(angle_deg)
+    return v * np.cos(theta) + np.cross(k, v) * np.sin(theta)
+
+
+def test_calc_angle_errors_returns_angle_pos_ome_order(monkeypatch):
+    """err_ini must be (angle, pos, ome) with each value distinguishable by
+    its known, filter-implied bound — not silently permuted."""
+    y_orig, z_orig, omega_ini = 300.0, 150.0, 12.0
+
+    # Ground-truth "observed, corrected" spot: grain position (0,0,0) makes
+    # _displacement_in_the_spot exactly (0, 0), so the corrected spot is
+    # just _correct_for_ome applied directly to the raw (y_orig, z_orig).
+    ys0, zs0, omega_corr0, g1_0, g2_0, g3_0 = c_port._correct_for_ome(
+        y_orig, z_orig, LSD, omega_ini, WAVELENGTH, wedge_deg=0.0,
+    )
+
+    g_obs = np.array([g1_0, g2_0, g3_0])
+    g_th = _rotate_by_small_angle(g_obs, ANGLE_ERR_DEG)
+
+    theor_spots = np.array([[
+        ys0 + POS_ERR_UM, zs0, omega_corr0 + OME_ERR_DEG,
+        g_th[0], g_th[1], g_th[2],
+        LSD, float(RING_NR), 0.0,
+    ]])
+
+    monkeypatch.setattr(
+        c_port, "calc_diffr_spots_furnace",
+        lambda *a, **k: theor_spots,
+    )
+
+    spots_yzo = np.array([[
+        ys0, zs0, omega_corr0, 1.0,       # YLab, ZLab, Omega, SpotID
+        omega_ini, y_orig, z_orig,         # OmegaIni, YOrig, ZOrig
+        float(RING_NR), 0.0, 0.0,          # RingNr, maskTouched, FitRMSE
+    ]])
+
+    spots_comp, spots_yzog, err_ini, n_matched = c_port.calc_angle_errors(
+        pos=[0.0, 0.0, 0.0],
+        orient_mat=np.eye(3),
+        lat_c=[4.0, 4.0, 4.0, 90.0, 90.0, 90.0],
+        spots_yzo=spots_yzo,
+        hkls_int=np.array([[1, 0, 0]], dtype=np.int64),
+        ring_nr_per_hkl=np.array([RING_NR], dtype=np.int64),
+        lsd=LSD, wavelength=WAVELENGTH,
+        omega_ranges=np.zeros((1, 2)), box_sizes=np.zeros((1, 4)),
+        min_eta=0.0, wedge_deg=0.0,
+    )
+
+    assert n_matched == 1
+    mean_angle_deg, mean_pos_um, mean_ome_deg = err_ini
+    assert mean_angle_deg == pytest.approx(ANGLE_ERR_DEG, abs=1e-6)
+    assert mean_pos_um == pytest.approx(POS_ERR_UM, abs=1e-6)
+    assert mean_ome_deg == pytest.approx(OME_ERR_DEG, abs=1e-6)
+
+    # Boundedness the driver relies on to tell the three apart: angle < 1,
+    # ome < 5, position unbounded by any matching filter.
+    assert mean_angle_deg < 1.0
+    assert mean_ome_deg < 5.0
+    assert mean_pos_um > 5.0
+
+    # The driver's GrainResult mapping (mirrors driver.py's post-fix
+    # unpacking) must land each value in the OrientPosFit.bin column whose
+    # Grains.csv header claims it — this is what a naive
+    # ErrorPos=err_ini[0]/ErrorOme=err_ini[1]/ErrorAngle=err_ini[2] mapping
+    # would get wrong.
+    grain_result = GrainResult(
+        SpotID=1, OrientMat=np.eye(3).reshape(-1),
+        Position=np.zeros(3), LatticeFit=np.array([4.0, 4.0, 4.0, 90, 90, 90]),
+        ErrorPos=mean_pos_um, ErrorOme=mean_ome_deg, ErrorAngle=mean_angle_deg,
+        meanRadius=0.0, completeness=1.0,
+    )
+    row = grain_result.to_row()
+    # col 22 = DiffPos in Grains.csv: must be the (unbounded) position error.
+    assert row[22] == pytest.approx(POS_ERR_UM, abs=1e-6)
+    # col 23 = DiffOme in Grains.csv: must be the omega error (< 5 deg).
+    assert row[23] == pytest.approx(OME_ERR_DEG, abs=1e-6)
+    # col 24 = DiffAngle in Grains.csv: must be the internal angle (< 1 deg).
+    assert row[24] == pytest.approx(ANGLE_ERR_DEG, abs=1e-6)

--- a/packages/midas_fit_grain/tests/test_io_binary.py
+++ b/packages/midas_fit_grain/tests/test_io_binary.py
@@ -61,7 +61,7 @@ def test_grain_result_layout():
         OrientMat=np.arange(9, dtype=np.float64),
         Position=np.array([1.0, 2.0, 3.0]),
         LatticeFit=np.array([4.04, 4.04, 4.04, 90.0, 90.0, 90.0]),
-        ErrorPos=0.1, ErrorOrient=0.2, ErrorStrain=0.3,
+        ErrorPos=0.1, ErrorOme=0.2, ErrorAngle=0.3,
         meanRadius=50.0, completeness=0.99,
     )
     row = g.to_row()
@@ -69,7 +69,8 @@ def test_grain_result_layout():
     # Layout per FitPosOrStrainsOMP.c:3007-3025:
     #   [0]=SpotID, [1..9]=OrientMat, [10]=SpotID, [11..13]=Pos,
     #   [14]=SpotID, [15..20]=Lattice, [21]=SpotID,
-    #   [22..24]=Errors, [25]=meanRadius, [26]=completeness
+    #   [22]=ErrorPos(pos,um), [23]=ErrorOme(ome,deg), [24]=ErrorAngle(IA,deg),
+    #   [25]=meanRadius, [26]=completeness
     assert row[0] == 42 and row[10] == 42 and row[14] == 42 and row[21] == 42
     np.testing.assert_array_equal(row[1:10], np.arange(9))
     np.testing.assert_array_equal(row[11:14], [1.0, 2.0, 3.0])
@@ -84,13 +85,13 @@ def test_orient_pos_fit_pwrite_strided(tmp_path):
     g0 = GrainResult(
         SpotID=10, OrientMat=np.zeros(9), Position=np.array([1, 2, 3]),
         LatticeFit=np.array([1, 2, 3, 4, 5, 6]),
-        ErrorPos=0.1, ErrorOrient=0.2, ErrorStrain=0.3,
+        ErrorPos=0.1, ErrorOme=0.2, ErrorAngle=0.3,
         meanRadius=10.0, completeness=0.5,
     )
     g3 = GrainResult(
         SpotID=99, OrientMat=np.ones(9), Position=np.array([7, 8, 9]),
         LatticeFit=np.array([10, 20, 30, 40, 50, 60]),
-        ErrorPos=1.1, ErrorOrient=1.2, ErrorStrain=1.3,
+        ErrorPos=1.1, ErrorOme=1.2, ErrorAngle=1.3,
         meanRadius=20.0, completeness=0.9,
     )
     write_orient_pos_fit_row(p, 0, g0)


### PR DESCRIPTION
driver.py assigned calc_angle_errors's (mean_angle, mean_pos, mean_ome) tuple straight into ErrorPos/ErrorOrient/ErrorStrain in return order, but OrientPosFit.bin cols 22-24 (which midas_process_grains reads back as Grains.csv's DiffPos/DiffOme/DiffAngle) expect (pos, ome, angle) per the C reference (FitPosOrStrainsOMP.c CalcAngleErrors: Error[0]=PosErr, Error[1]=OmeErr, Error[2]=IntAngle). Every FF/PF run through the python/torch refiner (midas-ff-pipeline / midas-pipeline) wrote all three columns cyclically mislabeled; the classic C refiner path was unaffected.

Fix unpacks err_ini by name instead of index, renames the misleading ErrorOrient/ErrorStrain fields to ErrorOme/ErrorAngle to match what they actually hold, and documents the column contract at both ends. Adds a deterministic regression test (synthetic matched spot with distinct angle/position/omega magnitudes) that fails under the old mapping and would have caught this — the existing io_binary tests only round-tripped values through the binary layer without checking calc_angle_errors's actual semantic order.

Bumps midas-fit-grain 0.5.6 -> 0.5.7.